### PR TITLE
fix(nav): remove arrow navigation in input stage (#1)

### DIFF
--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -82,13 +82,13 @@ func (m *InputsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Interrupt
 		case "esc":
 			return m, tea.Quit
-		case "right", "ctrl+n":
+		case "ctrl+n":
 			if m.hasValidInputs() {
 				m.updateInputsFromTemp()
 				m.mainModel.moveToNextStage()
 				return m.mainModel, nil
 			}
-		case "ctrl+p", "left":
+		case "ctrl+p":
 			m.mainModel.moveToPreviousStage()
 			return m.mainModel, nil
 		}


### PR DESCRIPTION
## Description
Removed arrow keys navigation in the input stage, so arrow keys to can be used to navigate input text

## Related Issues
Closes #1 

## Changes Made
- Removed left and right arrow key in the input stage navigation