### PR TITLE
feat(config): change config search from global to repo level

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Use the [setup-catalyst](https://github.com/PraveenGongada/setup-catalyst) actio
 - name: Setup Catalyst
   uses: PraveenGongada/setup-catalyst@v1
   with:
-    version: 'latest' # or specify a version like 'v1.0.0'
+    version: "latest" # or specify a version like 'v1.0.0'
 ```
 
 ### Homebrew
@@ -85,12 +85,11 @@ Catalyst looks for the configuration file in the following order:
 
 1. Path specified with the `-config` flag
 2. Path set in the `CATALYST_CONFIG` environment variable
-3. `./catalyst.yaml` in the current directory
-4. `$USER_CONFIG_DIR/catalyst/catalyst.yaml` (e.g., `~/.config/catalyst/catalyst.yaml` on Linux)
+3. `catalyst.yaml` in the current or git root directory
 
 ### Adding to Your Shell Profile
 
-Add the following to your `.zshrc`, `.bashrc`, or equivalent:
+You can optionally set the configuration path using an environment variable. Add the following to your `.zshrc`, `.bashrc`, or equivalent:
 
 ```bash
 # Set the path to your catalyst config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -53,8 +54,8 @@ type InputConfig struct {
 type PlatformConfig map[string]EnvironmentConfig
 
 type EnvironmentConfig struct {
-	Workflow string                 `yaml:"workflow"`
-	Matrix   map[string]interface{} `yaml:"matrix"`
+	Workflow string         `yaml:"workflow"`
+	Matrix   map[string]any `yaml:"matrix"`
 }
 
 func Load(path string) (*Config, error) {
@@ -64,9 +65,11 @@ func Load(path string) (*Config, error) {
 		} else {
 			path = "catalyst.yaml"
 			if _, err := os.Stat(path); os.IsNotExist(err) {
-				configDir, err := os.UserConfigDir()
-				if err == nil {
-					path = filepath.Join(configDir, "catalyst", "catalyst.yaml")
+				if gitRoot := getGitRoot(); gitRoot != "" {
+					gitRootPath := filepath.Join(gitRoot, "catalyst.yaml")
+					if _, err := os.Stat(gitRootPath); err == nil {
+						path = gitRootPath
+					}
 				}
 			}
 		}
@@ -83,6 +86,15 @@ func Load(path string) (*Config, error) {
 	}
 
 	return &config, nil
+}
+
+func getGitRoot() string {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
This PR changes the configuration file search behavior:

- Remove user config directory from search path
- Search for catalyst.yaml in git root directory
- Update documentation to reflect simplified search order
- Add getGitRoot() helper function